### PR TITLE
Implement fade transition for menu navigation

### DIFF
--- a/foci.html
+++ b/foci.html
@@ -8,11 +8,13 @@
 </head>
 <body>
     <div id="nav-container"></div>
-    <main class="card">
-        <h1>Foci</h1>
-        <p>A labdarúgás egy népszerű csapatsport, amelyet két 11 fős csapat játszik. A cél, hogy a labdát az ellenfél kapujába juttassák.</p>
-        <p>Híres játékos: Lionel Messi.</p>
-    </main>
+    <div id="content">
+        <main class="card">
+            <h1>Foci</h1>
+            <p>A labdarúgás egy népszerű csapatsport, amelyet két 11 fős csapat játszik. A cél, hogy a labdát az ellenfél kapujába juttassák.</p>
+            <p>Híres játékos: Lionel Messi.</p>
+        </main>
+    </div>
     <div id="footer-container"></div>
     <script src="nav.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -8,10 +8,12 @@
 </head>
 <body>
     <div id="nav-container"></div>
-    <main class="card">
-        <h1>Üdvözöl a Sport és Űrutazás oldal</h1>
-        <p>Válassz a fenti menüből, hogy megismerj különböző sportokat vagy az űrutazást.</p>
-    </main>
+    <div id="content">
+        <main class="card">
+            <h1>Üdvözöl a Sport és Űrutazás oldal</h1>
+            <p>Válassz a fenti menüből, hogy megismerj különböző sportokat vagy az űrutazást.</p>
+        </main>
+    </div>
     <div id="footer-container"></div>
     <script src="nav.js"></script>
 </body>

--- a/nav.js
+++ b/nav.js
@@ -1,28 +1,71 @@
-// Load navigation bar and footer, setup mobile menu
+// Setup navigation and dynamic page loading with fade transition
 window.addEventListener('DOMContentLoaded', () => {
-    // Navigation
+    const content = document.getElementById('content');
+
+    // Load navigation only once
     fetch('nav.html')
         .then(resp => resp.text())
         .then(html => {
             document.getElementById('nav-container').innerHTML = html;
             const menu = document.querySelector('.menu');
             const toggle = menu.querySelector('.menu-toggle');
-            toggle.addEventListener('click', () => {
-                menu.classList.toggle('open');
-            });
+            toggle.addEventListener('click', () => menu.classList.toggle('open'));
             menu.querySelectorAll('.links a').forEach(a => {
-                a.addEventListener('click', () => menu.classList.remove('open'));
+                a.addEventListener('click', evt => {
+                    evt.preventDefault();
+                    menu.classList.remove('open');
+                    const url = a.getAttribute('href');
+                    history.pushState(null, '', url);
+                    setActive(url);
+                    loadContent(url);
+                });
             });
-            const page = location.pathname.split('/').pop();
-            const active = menu.querySelector(`a[href="${page}"]`);
-            if (active) active.classList.add('active');
+            const page = location.pathname.split('/').pop() || 'index.html';
+            setActive(page);
+            // When landing on a page directly, ensure correct content is loaded
+            if (page !== 'index.html') loadContent(page);
         });
 
-    // Footer
+    // Footer (static)
     fetch('footer.html')
         .then(resp => resp.text())
         .then(html => {
             const container = document.getElementById('footer-container');
             if (container) container.innerHTML = html;
         });
+
+    // Handle browser navigation
+    window.addEventListener('popstate', () => {
+        const page = location.pathname.split('/').pop() || 'index.html';
+        setActive(page);
+        loadContent(page);
+    });
+
+    function setActive(page) {
+        const menu = document.querySelector('.menu');
+        if (!menu) return;
+        menu.querySelectorAll('.links a').forEach(a => {
+            a.classList.toggle('active', a.getAttribute('href') === page);
+        });
+    }
+
+    function loadContent(url) {
+        if (!content) return;
+        fetch(url)
+            .then(resp => resp.text())
+            .then(html => {
+                const parser = new DOMParser();
+                const doc = parser.parseFromString(html, 'text/html');
+                const main = doc.querySelector('#content > main, main');
+                if (!main) return;
+                const newHtml = main.innerHTML;
+                document.title = doc.title;
+                content.classList.add('fade-out');
+                content.addEventListener('transitionend', function handler() {
+                    content.removeEventListener('transitionend', handler);
+                    content.innerHTML = `<main class="card">${newHtml}</main>`;
+                    content.classList.remove('fade-out');
+                }, { once: true });
+            });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -96,6 +96,14 @@ main {
     font-size: 20px;
 }
 
+#content {
+    transition: opacity 0.3s ease;
+}
+
+#content.fade-out {
+    opacity: 0;
+}
+
 @media (max-width: 600px) {
     .menu .links {
         display: none;

--- a/ur.html
+++ b/ur.html
@@ -8,10 +8,12 @@
 </head>
 <body>
     <div id="nav-container"></div>
-    <main class="card">
-        <h1>Űrutazás</h1>
-        <img src="Assets/Ur.jpg" alt="Űrutazás képe" class="featured-image">
-    </main>
+    <div id="content">
+        <main class="card">
+            <h1>Űrutazás</h1>
+            <img src="Assets/Ur.jpg" alt="Űrutazás képe" class="featured-image">
+        </main>
+    </div>
     <div id="footer-container"></div>
     <script src="nav.js"></script>
 </body>

--- a/uszas.html
+++ b/uszas.html
@@ -8,11 +8,13 @@
 </head>
 <body>
     <div id="nav-container"></div>
-    <main class="card">
-        <h1>Úszás</h1>
-        <p>Az úszás minden izomcsoportot megmozgató vízisport, amely egyaránt fejleszti az állóképességet és erőt.</p>
-        <p>Híres úszók: Michael Phelps, Hosszú Katinka.</p>
-    </main>
+    <div id="content">
+        <main class="card">
+            <h1>Úszás</h1>
+            <p>Az úszás minden izomcsoportot megmozgató vízisport, amely egyaránt fejleszti az állóképességet és erőt.</p>
+            <p>Híres úszók: Michael Phelps, Hosszú Katinka.</p>
+        </main>
+    </div>
     <div id="footer-container"></div>
     <script src="nav.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- keep a single persistent navigation bar
- load page content dynamically and fade between views
- add CSS transition helpers
- wrap existing pages in a `#content` container for dynamic loading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ac0d219fc8323a8df27940df20cf1