### PR TITLE
Add sticky header search toggle

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -6,4 +6,8 @@
         <a href="uszas.html">Úszás</a>
         <a href="ur.html">Űrutazás</a>
     </div>
+    <div class="search-container">
+        <button class="search-toggle" aria-label="Search">&#128269;</button>
+        <input type="text" class="search-input" placeholder="Keresés...">
+    </div>
 </nav>

--- a/nav.js
+++ b/nav.js
@@ -19,6 +19,24 @@ window.addEventListener('DOMContentLoaded', () => {
                     menu.classList.toggle('open');
                 }
             });
+            const search = menu.querySelector('.search-container');
+            if (search) {
+                const searchToggle = search.querySelector('.search-toggle');
+                const input = search.querySelector('.search-input');
+                const toggleSearch = () => {
+                    search.classList.toggle('open');
+                    if (search.classList.contains('open')) {
+                        input.focus();
+                    }
+                };
+                searchToggle.addEventListener('click', toggleSearch);
+                searchToggle.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        toggleSearch();
+                    }
+                });
+            }
             menu.querySelectorAll('.links a').forEach(a => {
                 a.addEventListener('click', evt => {
                     evt.preventDefault();

--- a/style.css
+++ b/style.css
@@ -19,6 +19,9 @@ body {
     display: flex;
     align-items: center;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    position: sticky;
+    top: 0;
+    z-index: 1000;
 }
 
 .menu .links {
@@ -66,6 +69,33 @@ body {
     cursor: pointer;
     background: none;
     border: none;
+}
+
+.search-container {
+    position: relative;
+    margin-right: 10px;
+}
+
+.search-input {
+    width: 0;
+    padding: 6px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    transition: width 0.3s, opacity 0.3s;
+    opacity: 0;
+}
+
+.search-container.open .search-input {
+    width: 150px;
+    opacity: 1;
+}
+
+.search-toggle {
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 14px 20px;
 }
 
 main {


### PR DESCRIPTION
## Summary
- make `.menu` sticky so the header stays visible while scrolling
- embed a search icon and expanding input into `nav.html`
- style the new search field
- add JS to toggle the search field on click or key press

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687acc8c81b88323846f0ff811eece41