### PR TITLE
Add cookie policy and consent banner

### DIFF
--- a/cookie-banner.js
+++ b/cookie-banner.js
@@ -1,0 +1,47 @@
+(function() {
+    function createBanner() {
+        const banner = document.createElement('div');
+        banner.className = 'cookie-banner';
+        banner.innerHTML = `
+            <p>Az oldal cookie-kat használ a jobb felhasználói élmény érdekében. Részletek a <a href="cookie.html">sütiszabályzatban</a>.</p>
+            <div class="buttons">
+                <button class="accept">Elfogadom</button>
+                <button class="decline">Elutasítom</button>
+            </div>`;
+        banner.querySelector('.accept').addEventListener('click', () => {
+            setConsent('accepted');
+        });
+        banner.querySelector('.decline').addEventListener('click', () => {
+            setConsent('rejected');
+        });
+        document.body.appendChild(banner);
+        return banner;
+    }
+
+    function setConsent(value) {
+        try {
+            localStorage.setItem('cookie_consent', value);
+        } catch (_) {}
+        const b = document.querySelector('.cookie-banner');
+        if (b) b.remove();
+    }
+
+    function showBanner() {
+        try {
+            if (!localStorage.getItem('cookie_consent')) {
+                createBanner();
+            }
+        } catch (_) {
+            createBanner();
+        }
+    }
+
+    window.resetCookieConsent = function() {
+        try {
+            localStorage.removeItem('cookie_consent');
+        } catch (_) {}
+        location.reload();
+    };
+
+    window.addEventListener('DOMContentLoaded', showBanner);
+})();

--- a/cookie.html
+++ b/cookie.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sütiszabályzat</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="nav-container"></div>
+    <div id="content">
+        <main class="card">
+            <h1>Sütiszabályzat</h1>
+            <p>Ez a weboldal sütiket (cookie) használ a működés biztosításához és a felhasználói élmény javításához. A sütik kisméretű adatfájlok, amelyeket a böngésző tárol.</p>
+            <p>Két fő típust különböztetünk meg: szükséges sütik, melyek nélkül a weboldal nem tud megfelelően működni, valamint opcionális sütik, melyek statisztikai vagy marketing célt szolgálhatnak.</p>
+            <p>Amennyiben az "Elfogadom" gombra kattintasz, minden süti használatát engedélyezed. Az "Elutasítom" opció esetén csak a szükséges sütik maradnak aktívak. Döntésedet böngésződ helyi tárhelyén tároljuk, hogy legközelebb ne jelenjen meg a figyelmeztetés.</p>
+            <p>A sütik törlését vagy tiltását böngésződ beállításain keresztül is elvégezheted. További információkért keresd fel a böngésződ súgóját.</p>
+        </main>
+    </div>
+    <div id="footer-container"></div>
+    <script src="https://unpkg.com/feather-icons"></script>
+    <script src="nav.js"></script>
+    <script src="cookie-banner.js"></script>
+</body>
+</html>

--- a/foci.html
+++ b/foci.html
@@ -20,5 +20,6 @@
     <div id="footer-container"></div>
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="nav.js"></script>
+    <script src="cookie-banner.js"></script>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -8,4 +8,5 @@
         </a>
     </div>
     <p>&copy; 2023 Portfolio | info@example.com</p>
+    <p><a href="cookie.html">Cookie-szabályzat</a> | <a href="#" onclick="resetCookieConsent(); return false;">Sütibeállítások módosítása</a></p>
 </footer>

--- a/index.html
+++ b/index.html
@@ -32,5 +32,6 @@
     <div id="footer-container"></div>
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="nav.js"></script>
+    <script src="cookie-banner.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -233,3 +233,45 @@ main {
         grid-template-columns: 1fr;
     }
 }
+
+/* Cookie banner */
+.cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--color-blue);
+    color: var(--text-color);
+    padding: 10px;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.2);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    z-index: 10000;
+    text-align: center;
+}
+.cookie-banner p {
+    margin: 0 10px 5px 0;
+}
+.cookie-banner .buttons {
+    display: flex;
+    gap: 5px;
+}
+.cookie-banner button {
+    border: none;
+    border-radius: 4px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+.cookie-banner button.accept {
+    background-color: var(--color-green);
+}
+.cookie-banner button.decline {
+    background-color: var(--color-purple);
+}
+.cookie-banner a {
+    color: var(--text-color);
+    text-decoration: underline;
+}
+

--- a/ur.html
+++ b/ur.html
@@ -19,5 +19,6 @@
     <div id="footer-container"></div>
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="nav.js"></script>
+    <script src="cookie-banner.js"></script>
 </body>
 </html>

--- a/uszas.html
+++ b/uszas.html
@@ -20,5 +20,6 @@
     <div id="footer-container"></div>
     <script src="https://unpkg.com/feather-icons"></script>
     <script src="nav.js"></script>
+    <script src="cookie-banner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add simple cookie banner with accept/decline
- provide a cookie policy page
- link policy and settings from the footer
- include banner script on all pages
- style the banner

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687acfd75f6c8323bd0310686a795dfb