### PR TITLE
Add random YouTube short to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,12 @@
                     <span class="label">Űrutazás</span>
                 </a>
             </section>
+            <div id="random-video"></div>
         </main>
     </div>
     <div id="footer-container"></div>
     <script src="https://unpkg.com/feather-icons"></script>
+    <script src="random-video.js"></script>
     <script src="nav.js"></script>
     <script src="cookie-banner.js"></script>
 </body>

--- a/nav.js
+++ b/nav.js
@@ -204,6 +204,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     content.removeEventListener('transitionend', handler);
                     content.innerHTML = `<main class="card">${newHtml}</main>`;
                     content.classList.remove('fade-out');
+                    if (url === "index.html" && window.initRandomVideo) window.initRandomVideo();
                 }, { once: true });
             })
             .catch(err => {

--- a/random-video.js
+++ b/random-video.js
@@ -1,0 +1,17 @@
+window.initRandomVideo = function() {
+  const container = document.getElementById('random-video');
+  if (!container) return;
+  const videoIds = [
+    'Jvv3sMaI4H8',
+    'eaXs9Szp96I',
+    'vdrHYgIKKkc',
+    'Khh_5fRGHwE',
+    'lm69j-kYFyM'
+  ];
+  const id = videoIds[Math.floor(Math.random() * videoIds.length)];
+  container.innerHTML = `<iframe width="560" height="315" src="https://www.youtube.com/embed/${id}?autoplay=1" title="Random video" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`;
+};
+
+window.addEventListener('DOMContentLoaded', () => {
+  window.initRandomVideo();
+});

--- a/style.css
+++ b/style.css
@@ -286,3 +286,6 @@ main {
     text-decoration: underline;
 }
 
+
+#random-video { margin-top: 20px; text-align: center; }
+#random-video iframe { max-width: 100%; }


### PR DESCRIPTION
## Summary
- add a script that picks a random YouTube short and inserts it into the homepage
- include new video container and script on the index page
- load the random video again when navigating back to the homepage
- minor styling for the video container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ad7070a648323ad14c82612d604b7